### PR TITLE
Check version label in wait_for_app as AWS endpoint appears to be broken

### DIFF
--- a/shovel/deploy.py
+++ b/shovel/deploy.py
@@ -138,7 +138,7 @@ def wait_for_app(eb_client, app_name, version_label):
         print "..."
         time.sleep(5)
         environment = environment_util.get_environment(eb_client, app_name=app_name, version_label=version_label)
-        if environment:
+        if environment and environment['VersionLabel'] == version_label:
             status = environment['Status']
     if status == 'Ready':
         print "Environment ready!"


### PR DESCRIPTION
The version label filter in describe environments seems to be broken as adding it leads to an empty result being returned.
